### PR TITLE
Full doc output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# Python byte-compiled / optimized / DLL files
+__pycache__/
 *.py[cod]
 
 # C extensions

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 __pycache__/
 *.py[cod]
 
+# Auto-generated manifest
+MANIFEST
+
 # C extensions
 *.so
 

--- a/json2tsv/__init__.py
+++ b/json2tsv/__init__.py
@@ -10,7 +10,7 @@ if bytes == str:  # Python 2.7
     import codecs
     open_read_utf8 = lambda f: codecs.getreader('utf8')(f, 'replace')
     open_write_utf8 = lambda f: codecs.getwriter('utf8')(f, 'replace')
-    unicode = unicode
+    unicode = unicode  # flake8: noqa
 else:
     import io
     open_read_utf8 = lambda f: io.TextIOWrapper(f.buffer, 'utf8', 'replace')

--- a/json2tsv/__init__.py
+++ b/json2tsv/__init__.py
@@ -10,6 +10,7 @@ if bytes == str:  # Python 2.7
     import codecs
     open_read_utf8 = lambda f: codecs.getreader('utf8')(f, 'replace')
     open_write_utf8 = lambda f: codecs.getwriter('utf8')(f, 'replace')
+    unicode = unicode
 else:
     import io
     open_read_utf8 = lambda f: io.TextIOWrapper(f.buffer, 'utf8', 'replace')

--- a/json2tsv/json2tsv.py
+++ b/json2tsv/json2tsv.py
@@ -9,7 +9,7 @@ import json
 import re
 import sys
 
-from . import open_read_utf8, open_write_utf8
+from . import open_read_utf8, open_write_utf8, unicode
 
 
 def main():

--- a/json2tsv/json2tsv.py
+++ b/json2tsv/json2tsv.py
@@ -8,7 +8,9 @@ import argparse
 import json
 import re
 import sys
+
 from . import open_read_utf8, open_write_utf8
+
 
 def main():
     input = open_read_utf8(sys.stdin)
@@ -54,6 +56,8 @@ def extract_row(fields, obj):
 
 
 def extract_value(field, obj):
+    if field == "-":  # Special case -- return whole json object
+        return obj
     parts = field.split('.')
     for p in parts:
         obj = obj.get(p)

--- a/json2tsv/json2tsv.py
+++ b/json2tsv/json2tsv.py
@@ -33,7 +33,7 @@ def run(input, output, fields, headers):
         try:
             obj_or_list = json.loads(line)
         except Exception as e:
-            sys.stderr.write('line %s is not valid JSON: %s\n' % (i+1, e))
+            sys.stderr.write('line %s is not valid JSON: %s\n' % (i + 1, e))
             continue
 
         if isinstance(obj_or_list, list):
@@ -47,8 +47,7 @@ def run(input, output, fields, headers):
             output.write('\n')
         else:
             sys.stderr.write('line %s is not a JSON list or object: %r\n' %
-                             (i+1, line))
-            continue
+                             (i + 1, line))
 
 
 def extract_row(fields, obj):


### PR DESCRIPTION
Addresses https://github.com/tapilab/json2tsv/issues/4

Implements "-" as a special field name for producing the full doc output as a column. 

```
$ echo -e '{"id":"123", "user":{"name":"mary", "gender":"female"}}\n{"id":"124", "user":{"name":"mark", "gender":"male"}}' | \
> json2tsv id - | sort -k1,1r | cut -f2
{"id": "124", "user": {"name": "mark", "gender": "male"}}
{"id": "123", "user": {"name": "mary", "gender": "female"}}
```
