### PR TITLE
Fixes python3 issue in json2tsv

### DIFF
--- a/json2tsv/tsv2json.py
+++ b/json2tsv/tsv2json.py
@@ -31,8 +31,7 @@ def main():
                         r[parts[-1]] = value
                     else:
                         d[field] = value
-                output.write('%s\n' % json.dumps(d, encoding='utf-8',
-                                                 ensure_ascii=False))
+                output.write('%s\n' % json.dumps(d, ensure_ascii=False))
         except Exception as e:
             sys.stderr.write('bad line %s\n' % e)
             print(sys.exc_info()[0])


### PR DESCRIPTION
I couldn't figure out any difference that `encoding` seems to make and it's been removed in python 3.  

```
$ python2.7
Python 2.7.11+ (default, Apr 17 2016, 14:00:29) 
[GCC 5.3.1 20160413] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import json
>>> json.dumps(u'\u1234', ensure_ascii=False, encoding='utf-8')
u'"\u1234"'
>>> json.dumps(u'\u1234', ensure_ascii=False)
u'"\u1234"'
```
