### PR TITLE
Adds type decoding to tsv2json

### DIFF
--- a/json2tsv/__init__.py
+++ b/json2tsv/__init__.py
@@ -4,15 +4,3 @@
 __author__ = 'Aron Culotta'
 __email__ = 'aronwc@gmail.com'
 __version__ = '0.1.1'
-
-
-if bytes == str:  # Python 2.7
-    import codecs
-    open_read_utf8 = lambda f: codecs.getreader('utf8')(f, 'replace')
-    open_write_utf8 = lambda f: codecs.getwriter('utf8')(f, 'replace')
-    my_unicode = unicode  # flake8: noqa
-else:
-    import io
-    open_read_utf8 = lambda f: io.TextIOWrapper(f.buffer, 'utf8', 'replace')
-    open_write_utf8 = lambda f: io.TextIOWrapper(f.buffer, 'utf8', 'replace')
-    my_unicode = str

--- a/json2tsv/tsv2json.py
+++ b/json2tsv/tsv2json.py
@@ -2,36 +2,95 @@
 """
 Convert tsv to json from stdin, assuming first line is header.
 
-e.g., cat my.tsv | tsv2json
+
+e.g., cat my.tsv | json2tsv int str bool
 """
+import argparse
 import json
 import sys
+import traceback
 
-from . import open_read_utf8, open_write_utf8
+from . import util
+
+TYPES = {
+    'str': lambda v: v,
+    'int': int,
+    'float': float,
+    'bool': lambda v: v.lower() in ("true", "t", "1", "y"),
+    'json': json.loads
+}
 
 
 def main():
-    output = open_write_utf8(sys.stdout)
-    header = None
-    for line in open_read_utf8(sys.stdin):
+    parser = argparse.ArgumentParser(
+        description='Convert tsv to json from stdin, assuming first line is ' +
+                    'header.')
+    parser.add_argument(
+        'type', nargs='*',
+        help='The types of column values in the order they appear in ' +
+             'the file.  If left unspecified, all columns will be ' +
+             'assumed to be `str`.  Possible types are `str`, `int`, ' +
+             '`float`, `bool`, or `json`.')
+    parser.add_argument('--null-str', default="null", help='fields to print')
+    args = parser.parse_args()
+
+    input = util.read(sys.stdin)
+    output = util.write(sys.stdout)
+
+    run(input, output, args.type, args.null_str)
+
+
+def run(input, output, type_strs, null_str):
+    # Read headers
+    headers = [util.unescape(val)
+               for val in input.readline().strip().split('\t')]
+
+    # Generate type processors
+    if len(type_strs) == 0:
+        types = [TYPES['str']] * len(headers)
+    else:
+        types = [TYPES[type_str] for type_str in type_strs]
+
+    # Read input one line at a time
+    for i, line in enumerate(input):
+        lineno = i + 2  # i starts at 0 and we read a header line, so add 2
+
+        # Read and parse the line
         try:
-            columns = line.strip().split('\t')
-            if not header:
-                header = columns
-            else:
-                d = {}
-                for field, value in zip(header, columns):
-                    if '.' in field:
-                        parts = field.split('.')
-                        r = d
-                        for p in parts[:-1]:
-                            if p not in r:
-                                r[p] = {}
-                            r = r[p]
-                        r[parts[-1]] = value
-                    else:
-                        d[field] = value
-                output.write('%s\n' % json.dumps(d, ensure_ascii=False))
-        except Exception as e:
-            sys.stderr.write('bad line %s\n' % e)
-            print(sys.exc_info()[0])
+            val_strs = line.strip().split('\t')
+            if len(val_strs) != len(headers):
+                sys.stderr.write(
+                    'line %s has %s columns, expected %s: %s\n' %
+                    (lineno, len(val_strs), len(headers), line.strip()))
+            values = [decode_value(val, type, null_str)
+                      for type, val in zip(types, val_strs)]
+        except Exception:
+            sys.stderr.write('can\'t parse line %s: %s\n' % (lineno, line))
+            sys.stderr.write(traceback.format_exc())
+            continue
+
+        # Build the doc
+        doc = {}
+        for header, value in zip(headers, values):
+            place_value_at_path(doc, header, value)
+
+        # Write it to the output
+        output.write(json.dumps(doc, ensure_ascii=False))
+        output.write('\n')
+
+
+def decode_value(val, type, null_str):
+    if val == null_str:
+        return None
+    else:
+        return type(val)
+
+
+def place_value_at_path(doc, path, value):
+    parts = path.split('.')
+    sub_doc = doc
+    for p in parts[:-1]:
+        if p not in sub_doc:
+            sub_doc[p] = {}
+        sub_doc = sub_doc[p]
+    sub_doc[parts[-1]] = value

--- a/json2tsv/util.py
+++ b/json2tsv/util.py
@@ -1,0 +1,29 @@
+import json
+
+if bytes == str:  # Python 2.7
+    import codecs
+    read = lambda f: codecs.getreader('utf8')(f, 'replace')
+    write = lambda f: codecs.getwriter('utf8')(f, 'replace')
+    unicode = unicode  # flake8: noqa
+else: # Python 3.x
+    import io
+    read = lambda f: io.TextIOWrapper(f.buffer, 'utf8', 'replace')
+    write = lambda f: io.TextIOWrapper(f.buffer, 'utf8', 'replace')
+    unicode = str
+
+
+def escape(val):
+    """Escape tabs and newlines"""
+    # return re.sub('[\n\t]', '    ', s)
+    u = unicode(val)
+    return u.replace('\t', '\\t').replace('\n', "\\n")
+
+def encode(val):
+    if isinstance(val, list) or isinstance(val, dict) or val is None:
+        return json.dumps(val)
+    else:
+        return escape(val)
+
+def unescape(val):
+    u = unicode(val)
+    return u.replace('\\t', '\t').replace('\\n', "\n")


### PR DESCRIPTION
The `tsv2json` utility currently expects that all values are strings.  

```
$ echo -e "rev_id\tdamaging\n1\ttrue\n2\tfalse\n3\tfalse" | tsv2json 
{"damaging": "true", "rev_id": "1"}
{"damaging": "false", "rev_id": "2"}
{"damaging": "false", "rev_id": "3"}
```

This is less useful and requires lots of work in `sed` to clean things up.  Adding type decoding will allow the following code to work. 

```
$ echo -e "rev_id\tdamaging\n1\ttrue\n2\tfalse\n3\tfalse" | tsv2json int bool 
{"damaging": true, "rev_id": 1}
{"damaging": false, "rev_id": 2}
{"damaging": false, "rev_id": 3}
```

Also a little bit of cleanup tested in Python 3.5 and 2.7.

```
$ echo -e "foo\tbar\n1\tnull\n2\ttrue\n3\tfalse" | python -c "from json2tsv import tsv2json;tsv2json.main()" int bool | python -c "from json2tsv import json2tsv;json2tsv.main()" foo bar --header
foo bar
1   null
2   True
3   False
```
